### PR TITLE
StazorDocument作成時のテンプレートパスに関する検証を修正

### DIFF
--- a/Source/Stazor.Abstractions/IStazorDocument.cs
+++ b/Source/Stazor.Abstractions/IStazorDocument.cs
@@ -6,10 +6,10 @@
 public interface IStazorDocument
 {
     /// <summary>
-    /// テンプレートのパスを取得します。
+    /// テンプレートファイルのパスを取得します。
     /// </summary>
     /// <value>
-    /// テンプレートパス
+    /// テンプレートファイルのパス
     /// </value>
     string TemplatePath { get; init; }
 

--- a/Source/Stazor.Core/Document.cs
+++ b/Source/Stazor.Core/Document.cs
@@ -10,12 +10,12 @@ public static class Document
     /// <summary>
     /// <see cref="StazorDocument"/>クラスの新しいインスタンスを作成します。
     /// </summary>
-    /// <param name="templatePath">テンプレートディレクトリのパス</param>
+    /// <param name="templatePath">テンプレートファイルのパス</param>
     /// <param name="metadata">メタデータ</param>
     /// <returns>ドキュメントインスタンス</returns>
     public static IStazorDocument Create(string templatePath, IStazorMetadata metadata)
     {
-        ThrowHelper.ThrowDirectoryNotFoundExceptionIfDirectoryNotFound(templatePath);
+        ArgumentNullException.ThrowIfNull(templatePath);
         ArgumentNullException.ThrowIfNull(metadata);
 
         return new StazorDocument(templatePath, Context.Create(), metadata);

--- a/Source/Stazor.Core/Helpers/ThrowHelper.cs
+++ b/Source/Stazor.Core/Helpers/ThrowHelper.cs
@@ -59,22 +59,4 @@ static class ThrowHelper
             throw new ArgumentException($"The argument '{paramName}' cannot be null, empty or contain only whitespace.", paramName);
         }
     }
-
-    /// <summary>
-    /// 対象のパスが存在しない場合、新しい例外をスローします。
-    /// </summary>
-    /// <param name="path">パス</param>
-    /// <param name="paramName">パラメーター名</param>
-    /// <exception cref="ArgumentNullException">パスがnullの場合にこの例外をスローします。</exception>
-    /// <exception cref="DirectoryNotFoundException">パスが存在しない場合にこの例外をスローします。</exception>
-    [DebuggerHidden]
-    public static void ThrowDirectoryNotFoundExceptionIfDirectoryNotFound(string path, [CallerArgumentExpression("path")] string? paramName = null)
-    {
-        ArgumentNullException.ThrowIfNull(path, paramName);
-
-        if (!Directory.Exists(path))
-        {
-            throw new DirectoryNotFoundException($"Could not find a part of the path '{path}'.");
-        }
-    }
 }

--- a/Source/Stazor.Core/StazorDocument.cs
+++ b/Source/Stazor.Core/StazorDocument.cs
@@ -5,7 +5,7 @@ namespace Stazor.Core;
 /// <summary>
 /// ドキュメント
 /// </summary>
-/// <param name="TemplatePath">テンプレートパス</param>
+/// <param name="TemplatePath">テンプレートファイルのパス</param>
 /// <param name="Context">コンテキスト</param>
 /// <param name="Metadata">メタデータ</param>
 sealed record StazorDocument(


### PR DESCRIPTION
ファイルパスなのにディレクトリパスの検証を行っていた。
ここでファイルパスを検証してもあまり意味がないので、nullチェックのみに変更。